### PR TITLE
per-ssh-tab: switch to per-ssh-tab independent bottom bar/polling

### DIFF
--- a/src/components/bottom-bar.component.ts
+++ b/src/components/bottom-bar.component.ts
@@ -86,24 +86,34 @@ import { CustomMetric } from '../config'
         </div>
     `,
     styles: [`
-        :host { display: block; position: absolute; bottom: 0; left: 0; right: 0; z-index: 100; width: 100%; }
+        :host { display: block; width: 100%; position: relative; box-sizing: border-box; }
         .stats-container {
-            position: absolute; bottom: 0; left: 0; right: 0; width: 100%; z-index: 10000; 
-            backdrop-filter: blur(8px); padding: 4px 12px; display: flex; gap: 12px;
-            justify-content: flex-start; align-items: center; border-top: 1px solid rgba(255,255,255,0.15);
-            min-height: 28px; max-height: 28px; color: rgba(255,255,255,0.9); user-select: none; font-size: 11px;
+            position: relative;
+            width: 100%;
+            box-sizing: border-box;
+            backdrop-filter: blur(8px);
+            padding: 6px 12px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px 12px;
+            justify-content: flex-start;
+            align-items: flex-start;
+            border-top: 1px solid rgba(255,255,255,0.15);
+            color: rgba(255,255,255,0.9);
+            user-select: none;
+            font-size: 11px;
         }
-        .stat-section { display: flex; align-items: center; gap: 6px; }
-        .stat-label { font-weight: 500; color: rgba(255,255,255,0.7); font-size: 12px; line-height: 1; min-width: 24px; }
-        .stat-content { display: flex; align-items: center; gap: 6px; }
-        .progress-bar-container { height: 6px; background-color: rgba(255,255,255,0.1); border-radius: 3px; overflow: hidden; width: 50px; }
+        .stat-section { display: flex; align-items: center; gap: 6px; flex: 0 0 auto; }
+        .stat-label { font-weight: 500; color: rgba(255,255,255,0.7); font-size: 12px; line-height: 1; min-width: 24px; white-space: nowrap; }
+        .stat-content { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+        .progress-bar-container { height: 6px; background-color: rgba(255,255,255,0.1); border-radius: 3px; overflow: hidden; width: 60px; }
         .progress-bar { height: 100%; transition: width 0.3s ease, background-color 0.3s ease; border-radius: 3px; }
-        .stat-value { font-family: monospace; font-size: 12px; color: rgba(255,255,255,0.9); line-height: 1; white-space: nowrap; text-align: left; }
-        .stat-separator { width: 1px; height: 16px; background-color: rgba(255,255,255,0.2); margin: 0 2px; }
-        .net-section { min-width: 100px; margin-left: auto; }
-        .net-container { display: flex; flex-direction: row; gap: 8px; font-family: monospace; font-size: 10px; align-items: center; }
-        .net-row { white-space: nowrap; display: flex; align-items: center; gap: 3px; line-height: 1; }
-        .net-value { display: inline-block; min-width: 40px; text-align: left; }
+        .stat-value { font-family: monospace; font-size: 12px; color: rgba(255,255,255,0.9); line-height: 1.4; white-space: nowrap; text-align: left; }
+        .stat-separator { width: 1px; min-height: 16px; background-color: rgba(255,255,255,0.2); margin: 0 2px; align-self: stretch; flex: 0 0 1px; }
+        .net-section { min-width: 120px; margin-left: auto; }
+        .net-container { display: flex; flex-direction: column; gap: 4px; font-family: monospace; font-size: 10px; align-items: flex-start; }
+        .net-row { white-space: nowrap; display: flex; align-items: center; gap: 4px; line-height: 1.2; }
+        .net-value { display: inline-block; min-width: 60px; text-align: left; }
         .download { color: #2ecc71; }
         .upload { color: #e74c3c; }
         .loading-text { color: rgba(255,255,255,0.6); font-size: 10px; font-style: italic; }
@@ -118,6 +128,9 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
     public styleConfig = { background: 'rgba(20, 20, 20, 0.85)' }
     private timerId: any = null
     private tabSubscription: Subscription | null = null
+    private configSubscriptions: Subscription[] = []
+    private boundSession: any = null
+    public useExternalController = false
 
     constructor(
         private statsService: StatsService,
@@ -126,7 +139,6 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
         private cdr: ChangeDetectorRef,
         private zone: NgZone
     ) {
-        (window as any).serverStatsBottomBar = this;
     }
 
     getCpuColor(): string {
@@ -150,6 +162,37 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
         return '#e74c3c';
     }
 
+    bindToSession(session: any) {
+        this.boundSession = session;
+        this.visible = true;
+        this.loading = true;
+    }
+
+    renderExternalStats(stats: any | null) {
+        this.visible = true;
+        if (stats) {
+            this.visible = true;
+            this.loading = false;
+            this.updateStats(stats);
+            this.currentStats = stats;
+        } else {
+            this.loading = false;
+        }
+        this.cdr.detectChanges();
+    }
+
+    setExternalLoading(isLoading: boolean) {
+        this.visible = true;
+        this.loading = isLoading;
+        this.cdr.detectChanges();
+    }
+
+    hideExternal() {
+        this.visible = false;
+        this.loading = true;
+        this.cdr.detectChanges();
+    }
+
     // 获取自定义指标的值
     getCustomValue(index: number): string {
         if (!this.currentStats.custom || !this.currentStats.custom[index]) return '-';
@@ -167,16 +210,40 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
         return Math.min(100, Math.max(0, (val / max) * 100));
     }
 
+    private resolveSession(): any {
+        if (this.boundSession) {
+            return this.boundSession;
+        }
+
+        let activeTab: any = this.app.activeTab;
+        if (!activeTab) {
+            return null;
+        }
+
+        if (activeTab['focusedTab']) {
+            activeTab = activeTab['focusedTab'];
+        }
+
+        return activeTab['session'] || null;
+    }
+
     ngOnInit() {
         this.loadConfig();
-        this.config.ready$.subscribe(() => {
+        this.configSubscriptions.push(this.config.ready$.subscribe(() => {
             this.loadConfig();
             setTimeout(() => this.checkAndFetch(), 100);
-        });
-        this.config.changed$.subscribe(() => this.loadConfig());
-        this.tabSubscription = (this.app as any).activeTabChange.subscribe(() => {
-            this.checkAndFetch();
-        });
+        }));
+        this.configSubscriptions.push(this.config.changed$.subscribe(() => this.loadConfig()));
+
+        if (this.useExternalController) {
+            return;
+        }
+
+        if (!this.boundSession && (this.app as any).activeTabChange) {
+            this.tabSubscription = (this.app as any).activeTabChange.subscribe(() => {
+                this.checkAndFetch();
+            });
+        }
         setTimeout(() => this.checkAndFetch(), 100);
         this.zone.runOutsideAngular(() => {
             this.timerId = window.setInterval(() => {
@@ -206,6 +273,10 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
     forceUpdate() { this.checkAndFetch() }
 
     async checkAndFetch() {
+        if (this.useExternalController) {
+            return;
+        }
+
         const isEnabled = this.config.store.plugin?.serverStats?.enabled;
         const displayMode = this.config.store.plugin?.serverStats?.displayMode || 'bottomBar';
         
@@ -218,9 +289,9 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
             return;
         }
 
-        let activeTab: any = this.app.activeTab
+        const session = this.resolveSession();
 
-        if (!isEnabled || !activeTab) {
+        if (!isEnabled || !session) {
             if (this.visible) {
                 this.visible = false;
                 this.loading = true;
@@ -229,12 +300,6 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
             return;
         }
 
-        if (activeTab['focusedTab']) {
-            activeTab = activeTab['focusedTab'];
-        }
-
-        const session = activeTab['session'];
-        
         if (session && this.statsService.isPlatformSupport(session)) {
             if (!this.visible) {
                 this.visible = true;
@@ -270,5 +335,6 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
     ngOnDestroy() {
         if (this.timerId) clearInterval(this.timerId)
         if (this.tabSubscription) this.tabSubscription.unsubscribe()
+        this.configSubscriptions.forEach(sub => sub.unsubscribe())
     }
 }

--- a/src/components/bottom-bar.component.ts
+++ b/src/components/bottom-bar.component.ts
@@ -86,24 +86,34 @@ import { CustomMetric } from '../config'
         </div>
     `,
     styles: [`
-        :host { display: block; position: absolute; bottom: 0; left: 0; right: 0; z-index: 100; width: 100%; }
+        :host { display: block; width: 100%; position: relative; box-sizing: border-box; }
         .stats-container {
-            position: absolute; bottom: 0; left: 0; right: 0; width: 100%; z-index: 10000; 
-            backdrop-filter: blur(8px); padding: 4px 12px; display: flex; gap: 12px;
-            justify-content: flex-start; align-items: center; border-top: 1px solid rgba(255,255,255,0.15);
-            min-height: 28px; max-height: 28px; color: rgba(255,255,255,0.9); user-select: none; font-size: 11px;
+            position: relative;
+            width: 100%;
+            box-sizing: border-box;
+            backdrop-filter: blur(8px);
+            padding: 6px 12px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px 12px;
+            justify-content: flex-start;
+            align-items: center;
+            border-top: 1px solid rgba(255,255,255,0.15);
+            color: rgba(255,255,255,0.9);
+            user-select: none;
+            font-size: 11px;
         }
-        .stat-section { display: flex; align-items: center; gap: 6px; }
-        .stat-label { font-weight: 500; color: rgba(255,255,255,0.7); font-size: 12px; line-height: 1; min-width: 24px; }
-        .stat-content { display: flex; align-items: center; gap: 6px; }
-        .progress-bar-container { height: 6px; background-color: rgba(255,255,255,0.1); border-radius: 3px; overflow: hidden; width: 50px; }
+        .stat-section { display: flex; align-items: center; gap: 6px; flex: 0 0 auto; }
+        .stat-label { font-weight: 500; color: rgba(255,255,255,0.7); font-size: 12px; line-height: 1; min-width: 24px; white-space: nowrap; }
+        .stat-content { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+        .progress-bar-container { height: 6px; background-color: rgba(255,255,255,0.1); border-radius: 3px; overflow: hidden; width: 60px; }
         .progress-bar { height: 100%; transition: width 0.3s ease, background-color 0.3s ease; border-radius: 3px; }
-        .stat-value { font-family: monospace; font-size: 12px; color: rgba(255,255,255,0.9); line-height: 1; white-space: nowrap; text-align: left; }
-        .stat-separator { width: 1px; height: 16px; background-color: rgba(255,255,255,0.2); margin: 0 2px; }
-        .net-section { min-width: 100px; margin-left: auto; }
-        .net-container { display: flex; flex-direction: row; gap: 8px; font-family: monospace; font-size: 10px; align-items: center; }
-        .net-row { white-space: nowrap; display: flex; align-items: center; gap: 3px; line-height: 1; }
-        .net-value { display: inline-block; min-width: 40px; text-align: left; }
+        .stat-value { font-family: monospace; font-size: 12px; color: rgba(255,255,255,0.9); line-height: 1.4; white-space: nowrap; text-align: left; }
+        .stat-separator { width: 1px; min-height: 16px; background-color: rgba(255,255,255,0.2); margin: 0 2px; align-self: center; flex: 0 0 1px; }
+        .net-section { min-width: 120px; margin-left: auto; }
+        .net-container { display: flex; flex-direction: column; gap: 4px; font-family: monospace; font-size: 10px; align-items: flex-start; }
+        .net-row { white-space: nowrap; display: flex; align-items: center; gap: 4px; line-height: 1.2; }
+        .net-value { display: inline-block; min-width: 60px; text-align: left; }
         .download { color: #2ecc71; }
         .upload { color: #e74c3c; }
         .loading-text { color: rgba(255,255,255,0.6); font-size: 10px; font-style: italic; }
@@ -118,6 +128,9 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
     public styleConfig = { background: 'rgba(20, 20, 20, 0.85)' }
     private timerId: any = null
     private tabSubscription: Subscription | null = null
+    private configSubscriptions: Subscription[] = []
+    private boundSession: any = null
+    public useExternalController = false
 
     constructor(
         private statsService: StatsService,
@@ -126,7 +139,6 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
         private cdr: ChangeDetectorRef,
         private zone: NgZone
     ) {
-        (window as any).serverStatsBottomBar = this;
     }
 
     getCpuColor(): string {
@@ -150,6 +162,37 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
         return '#e74c3c';
     }
 
+    bindToSession(session: any) {
+        this.boundSession = session;
+        this.visible = true;
+        this.loading = true;
+    }
+
+    renderExternalStats(stats: any | null) {
+        this.visible = true;
+        if (stats) {
+            this.visible = true;
+            this.loading = false;
+            this.updateStats(stats);
+            this.currentStats = stats;
+        } else {
+            this.loading = false;
+        }
+        this.cdr.detectChanges();
+    }
+
+    setExternalLoading(isLoading: boolean) {
+        this.visible = true;
+        this.loading = isLoading;
+        this.cdr.detectChanges();
+    }
+
+    hideExternal() {
+        this.visible = false;
+        this.loading = true;
+        this.cdr.detectChanges();
+    }
+
     // 获取自定义指标的值
     getCustomValue(index: number): string {
         if (!this.currentStats.custom || !this.currentStats.custom[index]) return '-';
@@ -167,16 +210,40 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
         return Math.min(100, Math.max(0, (val / max) * 100));
     }
 
+    private resolveSession(): any {
+        if (this.boundSession) {
+            return this.boundSession;
+        }
+
+        let activeTab: any = this.app.activeTab;
+        if (!activeTab) {
+            return null;
+        }
+
+        if (activeTab['focusedTab']) {
+            activeTab = activeTab['focusedTab'];
+        }
+
+        return activeTab['session'] || null;
+    }
+
     ngOnInit() {
         this.loadConfig();
-        this.config.ready$.subscribe(() => {
+        this.configSubscriptions.push(this.config.ready$.subscribe(() => {
             this.loadConfig();
             setTimeout(() => this.checkAndFetch(), 100);
-        });
-        this.config.changed$.subscribe(() => this.loadConfig());
-        this.tabSubscription = (this.app as any).activeTabChange.subscribe(() => {
-            this.checkAndFetch();
-        });
+        }));
+        this.configSubscriptions.push(this.config.changed$.subscribe(() => this.loadConfig()));
+
+        if (this.useExternalController) {
+            return;
+        }
+
+        if (!this.boundSession && (this.app as any).activeTabChange) {
+            this.tabSubscription = (this.app as any).activeTabChange.subscribe(() => {
+                this.checkAndFetch();
+            });
+        }
         setTimeout(() => this.checkAndFetch(), 100);
         this.zone.runOutsideAngular(() => {
             this.timerId = window.setInterval(() => {
@@ -206,6 +273,10 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
     forceUpdate() { this.checkAndFetch() }
 
     async checkAndFetch() {
+        if (this.useExternalController) {
+            return;
+        }
+
         const isEnabled = this.config.store.plugin?.serverStats?.enabled;
         const displayMode = this.config.store.plugin?.serverStats?.displayMode || 'bottomBar';
         
@@ -218,9 +289,9 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
             return;
         }
 
-        let activeTab: any = this.app.activeTab
+        const session = this.resolveSession();
 
-        if (!isEnabled || !activeTab) {
+        if (!isEnabled || !session) {
             if (this.visible) {
                 this.visible = false;
                 this.loading = true;
@@ -229,12 +300,6 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
             return;
         }
 
-        if (activeTab['focusedTab']) {
-            activeTab = activeTab['focusedTab'];
-        }
-
-        const session = activeTab['session'];
-        
         if (session && this.statsService.isPlatformSupport(session)) {
             if (!this.visible) {
                 this.visible = true;
@@ -270,5 +335,6 @@ export class ServerStatsBottomBarComponent implements OnInit, OnDestroy {
     ngOnDestroy() {
         if (this.timerId) clearInterval(this.timerId)
         if (this.tabSubscription) this.tabSubscription.unsubscribe()
+        this.configSubscriptions.forEach(sub => sub.unsubscribe())
     }
 }

--- a/src/components/bottom-bar.component.ts
+++ b/src/components/bottom-bar.component.ts
@@ -97,7 +97,7 @@ import { CustomMetric } from '../config'
             flex-wrap: wrap;
             gap: 8px 12px;
             justify-content: flex-start;
-            align-items: flex-start;
+            align-items: center;
             border-top: 1px solid rgba(255,255,255,0.15);
             color: rgba(255,255,255,0.9);
             user-select: none;
@@ -109,7 +109,7 @@ import { CustomMetric } from '../config'
         .progress-bar-container { height: 6px; background-color: rgba(255,255,255,0.1); border-radius: 3px; overflow: hidden; width: 60px; }
         .progress-bar { height: 100%; transition: width 0.3s ease, background-color 0.3s ease; border-radius: 3px; }
         .stat-value { font-family: monospace; font-size: 12px; color: rgba(255,255,255,0.9); line-height: 1.4; white-space: nowrap; text-align: left; }
-        .stat-separator { width: 1px; min-height: 16px; background-color: rgba(255,255,255,0.2); margin: 0 2px; align-self: stretch; flex: 0 0 1px; }
+        .stat-separator { width: 1px; min-height: 16px; background-color: rgba(255,255,255,0.2); margin: 0 2px; align-self: center; flex: 0 0 1px; }
         .net-section { min-width: 120px; margin-left: auto; }
         .net-container { display: flex; flex-direction: column; gap: 4px; font-family: monospace; font-size: 10px; align-items: flex-start; }
         .net-row { white-space: nowrap; display: flex; align-items: center; gap: 4px; line-height: 1.2; }

--- a/src/components/bottom-bar.component.ts
+++ b/src/components/bottom-bar.component.ts
@@ -97,7 +97,7 @@ import { CustomMetric } from '../config'
             flex-wrap: wrap;
             gap: 8px 12px;
             justify-content: flex-start;
-            align-items: center;
+            align-items: flex-start;
             border-top: 1px solid rgba(255,255,255,0.15);
             color: rgba(255,255,255,0.9);
             user-select: none;
@@ -109,7 +109,7 @@ import { CustomMetric } from '../config'
         .progress-bar-container { height: 6px; background-color: rgba(255,255,255,0.1); border-radius: 3px; overflow: hidden; width: 60px; }
         .progress-bar { height: 100%; transition: width 0.3s ease, background-color 0.3s ease; border-radius: 3px; }
         .stat-value { font-family: monospace; font-size: 12px; color: rgba(255,255,255,0.9); line-height: 1.4; white-space: nowrap; text-align: left; }
-        .stat-separator { width: 1px; min-height: 16px; background-color: rgba(255,255,255,0.2); margin: 0 2px; align-self: center; flex: 0 0 1px; }
+        .stat-separator { width: 1px; min-height: 16px; background-color: rgba(255,255,255,0.2); margin: 0 2px; align-self: stretch; flex: 0 0 1px; }
         .net-section { min-width: 120px; margin-left: auto; }
         .net-container { display: flex; flex-direction: column; gap: 4px; font-family: monospace; font-size: 10px; align-items: flex-start; }
         .net-row { white-space: nowrap; display: flex; align-items: center; gap: 4px; line-height: 1.2; }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap'
 import TabbyCoreModule, { ToolbarButtonProvider, ConfigProvider, TranslateService, AppService, ConfigService } from 'tabby-core'
 import { SettingsTabProvider } from 'tabby-settings'
 import { NgChartsModule } from 'ng2-charts'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
 
 import { ServerStatsConfigProvider } from './config'
 import { TRANSLATIONS } from './translations'
@@ -13,6 +16,23 @@ import { StatsToolbarButtonProvider } from './toolbar-button.provider'
 import { ServerStatsFloatingPanelComponent } from './components/floating-panel.component'
 import { ServerStatsBottomBarComponent } from './components/bottom-bar.component'
 import { ServerStatsSettingsComponent, ServerStatsSettingsTabProvider } from './components/settings.component'
+
+type TabInstance = {
+    teardown: () => void
+    timerId: any
+    collector: () => Promise<any>
+    state: any
+    configSub: any
+}
+
+const LOG_PATH = path.join(os.tmpdir(), 'tabby-server-stats.log')
+const logDebug = (message: string) => {
+    try {
+        fs.appendFileSync(LOG_PATH, `${new Date().toISOString()} ${message}\n`)
+    } catch {}
+}
+
+logDebug('[init] module loaded')
 
 @NgModule({
     imports: [CommonModule, FormsModule, NgChartsModule, TabbyCoreModule, NgbModule], 
@@ -27,93 +47,561 @@ import { ServerStatsSettingsComponent, ServerStatsSettingsTabProvider } from './
 })
 export default class ServerStatsModule {
     private floatingRef: any = null
-    private bottomBarRef: any = null
     private floatingElem: HTMLElement | null = null
-    private bottomBarElem: HTMLElement | null = null
+    private activeDisplayMode: string | null = null
+    private tabInstances: WeakMap<HTMLElement, TabInstance> = new WeakMap()
+    private attachedTabs = new Set<HTMLElement>()
+    private tabElementMap = new Map<HTMLElement, any>()
+    private observer: MutationObserver | null = null
+    private disposables: Array<() => void> = []
+    private styleNode: HTMLStyleElement | null = null
+    private observerRetry: any = null
+    private failed = false
+    private mutationScheduled = false
+    private pendingAdded = new Set<HTMLElement>()
+    private pendingRemoved = new Set<HTMLElement>()
+    private mutationBurst = 0
+    private mutationBurstTimer: any = null
+    private scanTimer: any = null
 
     constructor(
-        app: AppService, 
-        config: ConfigService,
-        componentFactoryResolver: ComponentFactoryResolver,
-        appRef: ApplicationRef,
-        injector: Injector,
+        private app: AppService, 
+        private config: ConfigService,
+        private componentFactoryResolver: ComponentFactoryResolver,
+        private appRef: ApplicationRef,
+        private injector: Injector,
+        private statsService: StatsService,
         translate: TranslateService
     ) {
-        config.ready$.subscribe(() => {
+        logDebug('[init] constructor start')
+        this.config.ready$.subscribe(() => {
             setTimeout(() => {
-                for (const [lang, trans] of Object.entries(TRANSLATIONS)) {
-                    translate.setTranslation(lang, trans, true);
-                }
+                this.safeRun('translations', () => {
+                    for (const [lang, trans] of Object.entries(TRANSLATIONS)) {
+                        translate.setTranslation(lang, trans, true);
+                    }
+                })
             }, 1000);
         });
 
-        const createComponent = (displayMode: string) => {
-            this.destroyComponents()
-
-            if (displayMode === 'floatingPanel') {
-                const floatingFactory = componentFactoryResolver.resolveComponentFactory(ServerStatsFloatingPanelComponent)
-                this.floatingRef = floatingFactory.create(injector)
-                appRef.attachView(this.floatingRef.hostView)
-                this.floatingElem = (this.floatingRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
-                document.body.appendChild(this.floatingElem);
-                (window as any).serverStatsFloating = this.floatingRef.instance;
-                this.floatingRef.changeDetectorRef.detectChanges();
-                setTimeout(() => this.floatingRef.instance.checkAndFetch(), 100);
-            } else {
-                const bottomBarFactory = componentFactoryResolver.resolveComponentFactory(ServerStatsBottomBarComponent)
-                this.bottomBarRef = bottomBarFactory.create(injector)
-                appRef.attachView(this.bottomBarRef.hostView)
-                this.bottomBarElem = (this.bottomBarRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
-                const targetContainer = document.querySelector('app-root > div > .content');
-                if (targetContainer) {
-                    targetContainer.appendChild(this.bottomBarElem);
-                } else {
-                    document.body.appendChild(this.bottomBarElem);
-                }
-                (window as any).serverStatsBottomBar = this.bottomBarRef.instance;
-                this.bottomBarRef.changeDetectorRef.detectChanges();
-                setTimeout(() => this.bottomBarRef.instance.checkAndFetch(), 100);
-            }
-        }
-
-        const getDisplayMode = () => {
-            return config.store.plugin?.serverStats?.displayMode || 'bottomBar'
-        }
-
-        config.ready$.subscribe(() => {
+        this.config.ready$.subscribe(() => {
             setTimeout(() => {
-                createComponent(getDisplayMode())
+                logDebug('[event] config.ready')
+                this.safeRun('applyDisplayMode:ready', () => this.applyDisplayMode(this.getDisplayMode()))
             }, 500);
         })
 
-        config.changed$.subscribe(() => {
-            const currentMode = getDisplayMode()
-            const existingMode = this.floatingRef ? 'floatingPanel' : (this.bottomBarRef ? 'bottomBar' : null)
-            if (existingMode !== currentMode) {
-                createComponent(currentMode)
+        this.config.changed$.subscribe(() => {
+            logDebug('[event] config.changed')
+            this.safeRun('applyDisplayMode:changed', () => this.applyDisplayMode(this.getDisplayMode()))
+        })
+        logDebug('[init] constructor end')
+    }
+
+    private getDisplayMode() {
+        return this.config.store.plugin?.serverStats?.displayMode || 'bottomBar'
+    }
+
+    private safeRun(label: string, fn: () => void) {
+        if (this.failed) {
+            return
+        }
+        try {
+            fn()
+        } catch (err) {
+            this.failed = true
+            logDebug(`[error] ${label}: ${err instanceof Error ? err.stack || err.message : String(err)}`)
+        }
+    }
+
+    private applyDisplayMode(mode: string) {
+        logDebug(`[state] applyDisplayMode ${mode}`)
+        const previousMode = this.activeDisplayMode
+        this.activeDisplayMode = mode
+
+        if (previousMode === mode) {
+            if (mode === 'bottomBar' && this.attachedTabs.size === 0) {
+                this.initializePerTabBars()
+            }
+            return
+        }
+
+        this.destroyFloating()
+        this.teardownAllTabs()
+
+        if (mode === 'floatingPanel') {
+            this.safeRun('createFloatingPanel', () => this.createFloatingPanel())
+        } else {
+            this.safeRun('ensureGlobalStyle', () => this.ensureGlobalStyle())
+            this.safeRun('initializePerTabBars', () => this.initializePerTabBars())
+        }
+    }
+
+    private createFloatingPanel() {
+        logDebug('[state] createFloatingPanel')
+        const floatingFactory = this.componentFactoryResolver.resolveComponentFactory(ServerStatsFloatingPanelComponent)
+        this.floatingRef = floatingFactory.create(this.injector)
+        this.appRef.attachView(this.floatingRef.hostView)
+        this.floatingElem = (this.floatingRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
+        document.body.appendChild(this.floatingElem);
+        this.floatingRef.changeDetectorRef.detectChanges();
+        setTimeout(() => this.floatingRef.instance.checkAndFetch(), 100);
+    }
+
+    private initializePerTabBars() {
+        logDebug('[state] initializePerTabBars')
+        this.safeRun('rebuildTabElementMap', () => this.rebuildTabElementMap())
+        this.safeRun('attachExistingTabs', () => this.attachExistingTabs())
+        this.safeRun('observeTabLifecycle', () => this.observeTabLifecycle())
+        this.safeRun('startMutationObserver', () => this.startMutationObserver())
+        this.safeRun('startScanTimer', () => this.startScanTimer())
+    }
+
+    private ensureGlobalStyle() {
+        if (this.styleNode) {
+            return
+        }
+        if (!document.head) {
+            this.scheduleObserverRetry()
+            return
+        }
+        logDebug('[state] ensureGlobalStyle')
+        const style = document.createElement('style')
+        style.setAttribute('data-server-stats-style', '1')
+        style.textContent = `
+            ssh-tab.server-stats-tab {
+                display: flex;
+                flex-direction: column;
+            }
+            ssh-tab.server-stats-tab > .server-stats-bottom-host {
+                flex: 0 0 auto;
+                width: 100%;
+            }
+            ssh-tab.server-stats-tab > *:not(.server-stats-bottom-host) {
+                flex: 1 1 auto;
+                min-height: 0;
+            }
+            .server-stats-bottom-host {
+                width: 100%;
+            }
+        `
+        document.head.appendChild(style)
+        this.styleNode = style
+    }
+
+    private attachExistingTabs() {
+        const content = document.querySelector('app-root > div > .content')
+        if (!content) {
+            logDebug('[state] attachExistingTabs: no content')
+            this.scheduleObserverRetry()
+            return
+        }
+        this.rebuildTabElementMap()
+        const candidates = content.querySelectorAll('ssh-tab')
+        logDebug(`[state] attachExistingTabs ${candidates.length}`)
+        candidates.forEach(el => this.attachToSshTab(el as HTMLElement))
+    }
+
+    private startMutationObserver() {
+        const target = this.getObserverTarget()
+        if (!target) {
+            logDebug('[state] startMutationObserver: no target')
+            this.scheduleObserverRetry()
+            return
+        }
+        logDebug('[state] startMutationObserver: ok')
+        if (this.observer) {
+            this.observer.disconnect()
+        }
+        this.observer = new MutationObserver(mutations => {
+            this.trackMutationBurst(mutations.length)
+            mutations.forEach(mutation => {
+                mutation.addedNodes.forEach(node => this.queueMutationNode(node, true))
+                mutation.removedNodes.forEach(node => this.queueMutationNode(node, false))
+            })
+            this.flushMutationQueue()
+        })
+        this.observer.observe(target, { childList: true, subtree: true })
+    }
+
+    private queueMutationNode(node: Node, added: boolean) {
+        if (!(node instanceof HTMLElement)) {
+            return
+        }
+        if (added) {
+            this.pendingAdded.add(node)
+        } else {
+            this.pendingRemoved.add(node)
+        }
+    }
+
+    private flushMutationQueue() {
+        if (this.mutationScheduled) {
+            return
+        }
+        this.mutationScheduled = true
+        window.setTimeout(() => {
+            this.mutationScheduled = false
+            this.pendingAdded.forEach(node => this.scanNodeForTabs(node))
+            this.pendingRemoved.forEach(node => this.handleRemovedNode(node))
+            this.pendingAdded.clear()
+            this.pendingRemoved.clear()
+        }, 0)
+    }
+
+    private getObserverTarget(): HTMLElement | null {
+        return (document.querySelector('app-root > div > .content') as HTMLElement) || null
+    }
+
+    private trackMutationBurst(count: number) {
+        this.mutationBurst += count
+        if (!this.mutationBurstTimer) {
+            this.mutationBurstTimer = window.setTimeout(() => {
+                this.mutationBurst = 0
+                this.mutationBurstTimer = null
+            }, 1000)
+        }
+        if (this.mutationBurst > 2000 && this.observer) {
+            logDebug('[state] mutation burst detected, disabling observer')
+            this.observer.disconnect()
+            this.observer = null
+        }
+    }
+
+    private scheduleObserverRetry() {
+        if (this.observerRetry) {
+            return
+        }
+        logDebug('[state] scheduleObserverRetry')
+        this.observerRetry = window.setTimeout(() => {
+            this.observerRetry = null
+            if (this.activeDisplayMode === 'bottomBar') {
+                logDebug('[state] observerRetry tick')
+                this.safeRun('ensureGlobalStyle:retry', () => this.ensureGlobalStyle())
+                this.safeRun('attachExistingTabs:retry', () => this.attachExistingTabs())
+                this.safeRun('startMutationObserver:retry', () => this.startMutationObserver())
+            }
+        }, 250)
+    }
+
+    private scanNodeForTabs(node: Node) {
+        if (!(node instanceof HTMLElement)) {
+            return
+        }
+        if (node.tagName && node.tagName.toLowerCase() === 'ssh-tab') {
+            this.attachToSshTab(node)
+            return
+        }
+        const inner = node.querySelectorAll('ssh-tab')
+        inner.forEach(el => this.attachToSshTab(el as HTMLElement))
+    }
+
+    private handleRemovedNode(node: Node) {
+        if (!(node instanceof HTMLElement)) {
+            return
+        }
+        if (node.tagName && node.tagName.toLowerCase() === 'ssh-tab') {
+            if (this.tabInstances.has(node)) {
+                this.detachFromTab(node)
+            }
+            return
+        }
+        const inner = node.querySelectorAll('ssh-tab')
+        inner.forEach(el => this.detachFromTab(el as HTMLElement))
+    }
+
+    private startScanTimer() {
+        if (this.scanTimer) {
+            return
+        }
+        this.scanTimer = window.setInterval(() => {
+            if (this.activeDisplayMode !== 'bottomBar') {
+                return
+            }
+            this.attachExistingTabs()
+        }, 1500)
+    }
+
+    private attachToSshTab(sshTabEl: HTMLElement) {
+        if (this.activeDisplayMode !== 'bottomBar') {
+            return
+        }
+        if (!sshTabEl || this.tabInstances.has(sshTabEl) || sshTabEl.getAttribute('data-ss-attached') === '1') {
+            return
+        }
+        logDebug('[state] attachToSshTab')
+
+        this.rebuildTabElementMap()
+        sshTabEl.setAttribute('data-ss-attached', '1')
+        sshTabEl.classList.add('server-stats-tab')
+
+        const host = document.createElement('div')
+        host.classList.add('server-stats-bottom-host')
+        host.setAttribute('data-ss-host', '1')
+        sshTabEl.appendChild(host)
+
+        const barFactory = this.componentFactoryResolver.resolveComponentFactory(ServerStatsBottomBarComponent)
+        const barRef = barFactory.create(this.injector)
+        const session = this.resolveSessionForElement(sshTabEl)
+        if ((barRef.instance as any).useExternalController !== undefined) {
+            (barRef.instance as any).useExternalController = true
+        }
+        if ((barRef.instance as any).bindToSession) {
+            (barRef.instance as any).bindToSession(session)
+        }
+        this.appRef.attachView(barRef.hostView)
+        const barElem = (barRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
+        host.appendChild(barElem)
+        barRef.changeDetectorRef.detectChanges()
+
+        const state: any = { last: null }
+        let activeSession: any = session
+        const collector = async () => {
+            const resolvedSession = this.resolveSessionForElement(sshTabEl)
+            if (resolvedSession && resolvedSession !== activeSession) {
+                activeSession = resolvedSession
+                if ((barRef.instance as any).bindToSession) {
+                    (barRef.instance as any).bindToSession(activeSession)
+                }
+            }
+            if (!activeSession) {
+                return { data: null, session: null, supported: false }
+            }
+            const supported = this.statsService.isPlatformSupport(activeSession)
+            if (!supported) {
+                return { data: null, session: activeSession, supported: false }
+            }
+            const data = await this.statsService.fetchStats(activeSession)
+            return { data, session: activeSession, supported: true }
+        }
+
+        const runPoll = async () => {
+            const isEnabled = this.config.store.plugin?.serverStats?.enabled
+            const displayMode = this.getDisplayMode()
+            if (!isEnabled || displayMode !== 'bottomBar') {
+                if ((barRef.instance as any).hideExternal) {
+                    (barRef.instance as any).hideExternal()
+                }
+                return
+            }
+            const result = await collector()
+            if (!result) {
+                return
+            }
+            if (!result.session) {
+                if ((barRef.instance as any).hideExternal) {
+                    (barRef.instance as any).hideExternal()
+                }
+                return
+            }
+            if (!result.supported) {
+                if ((barRef.instance as any).hideExternal) {
+                    (barRef.instance as any).hideExternal()
+                }
+                return
+            }
+            if (result.data) {
+                state.last = result.data
+                if ((barRef.instance as any).renderExternalStats) {
+                    (barRef.instance as any).renderExternalStats(result.data)
+                }
+            } else if ((barRef.instance as any).setExternalLoading) {
+                (barRef.instance as any).setExternalLoading(false)
+            }
+        }
+
+        const syncOnConfigChange = () => {
+            const isEnabled = this.config.store.plugin?.serverStats?.enabled
+            const displayMode = this.getDisplayMode()
+            if (!isEnabled || displayMode !== 'bottomBar') {
+                if ((barRef.instance as any).hideExternal) {
+                    (barRef.instance as any).hideExternal()
+                }
+                return
+            }
+            if ((barRef.instance as any).setExternalLoading) {
+                (barRef.instance as any).setExternalLoading(true)
+            }
+            runPoll()
+        }
+
+        syncOnConfigChange()
+        const timerId = window.setInterval(runPoll, 3000)
+        const configSub = this.config.changed$?.subscribe(() => {
+            syncOnConfigChange()
+        })
+
+        const teardown = () => {
+            if (timerId) {
+                clearInterval(timerId)
+            }
+            if (configSub && typeof configSub.unsubscribe === 'function') {
+                configSub.unsubscribe()
+            }
+            try {
+                barRef.destroy()
+            } catch {}
+            try {
+                this.appRef.detachView(barRef.hostView)
+            } catch {}
+            if (host.parentNode === sshTabEl) {
+                host.parentNode.removeChild(host)
+            }
+            sshTabEl.removeAttribute('data-ss-attached')
+            sshTabEl.classList.remove('server-stats-tab')
+        }
+
+        this.tabInstances.set(sshTabEl, { teardown, timerId, collector, state, configSub })
+        this.attachedTabs.add(sshTabEl)
+    }
+
+    private detachFromTab(tabEl: HTMLElement) {
+        const existing = this.tabInstances.get(tabEl)
+        if (existing) {
+            logDebug('[state] detachFromTab')
+            existing.teardown()
+            this.tabInstances.delete(tabEl)
+        }
+        this.attachedTabs.delete(tabEl)
+        this.tabElementMap.delete(tabEl)
+    }
+
+    private rebuildTabElementMap() {
+        this.tabElementMap.clear()
+        const tabs = this.getAllLeafTabs()
+        tabs.forEach(tab => {
+            const el = this.getTabElement(tab)
+            if (el) {
+                this.tabElementMap.set(el, tab)
             }
         })
     }
 
-    private destroyComponents() {
+    private getAllLeafTabs(): any[] {
+        const result: any[] = []
+        const walk = (tab: any) => {
+            if (!tab) return
+            if (typeof tab.getAllTabs === 'function') {
+                const inner = tab.getAllTabs()
+                if (Array.isArray(inner)) {
+                    inner.forEach((t: any) => walk(t))
+                    return
+                }
+            }
+            result.push(tab)
+        }
+        if (Array.isArray(this.app.tabs)) {
+            this.app.tabs.forEach(tab => walk(tab))
+        }
+        return result
+    }
+
+    private getTabElement(tab: any): HTMLElement | null {
+        if (!tab) return null
+        const direct = tab.element && tab.element.nativeElement
+        if (direct instanceof HTMLElement) {
+            return direct
+        }
+        const hostView = tab.hostView && (tab.hostView as any).rootNodes
+        if (hostView && hostView[0] instanceof HTMLElement) {
+            return hostView[0]
+        }
+        const embedded = tab.viewContainerEmbeddedRef && tab.viewContainerEmbeddedRef.rootNodes
+        if (embedded && embedded[0] instanceof HTMLElement) {
+            return embedded[0]
+        }
+        return null
+    }
+
+    private resolveSessionForElement(el: HTMLElement): any {
+        const tab = this.tabElementMap.get(el)
+        if (tab) {
+            return this.resolveSessionFromTab(tab)
+        }
+        for (const [knownEl, knownTab] of this.tabElementMap.entries()) {
+            if (knownEl && knownEl.contains && knownEl.contains(el)) {
+                return this.resolveSessionFromTab(knownTab)
+            }
+        }
+        return null
+    }
+
+    private resolveSessionFromTab(tab: any): any {
+        if (!tab) return null
+        if (tab.session) return tab.session
+        if (tab.focusedTab) {
+            return this.resolveSessionFromTab(tab.focusedTab)
+        }
+        return null
+    }
+
+    private observeTabLifecycle() {
+        this.disposables.forEach(fn => fn())
+        this.disposables = []
+
+        const tabRemoved = this.app.tabRemoved$?.subscribe(tab => {
+            const el = this.getTabElement(tab)
+            if (el) {
+                this.detachFromTab(el)
+            }
+            this.rebuildTabElementMap()
+        })
+        const tabClosed = this.app.tabClosed$?.subscribe(tab => {
+            const el = this.getTabElement(tab)
+            if (el) {
+                this.detachFromTab(el)
+            }
+            this.rebuildTabElementMap()
+        })
+        const tabOpened = this.app.tabOpened$?.subscribe(() => {
+            this.rebuildTabElementMap()
+            this.attachExistingTabs()
+        })
+        const tabsChanged = this.app.tabsChanged$?.subscribe(() => {
+            this.rebuildTabElementMap()
+            this.attachExistingTabs()
+        })
+
+        ;[tabRemoved, tabClosed, tabOpened, tabsChanged].forEach(sub => {
+            if (sub && typeof sub.unsubscribe === 'function') {
+                this.disposables.push(() => sub.unsubscribe())
+            }
+        })
+    }
+
+    private destroyFloating() {
         if (this.floatingRef) {
+            try {
+                this.appRef.detachView(this.floatingRef.hostView)
+            } catch {}
             this.floatingRef.destroy()
             if (this.floatingElem && this.floatingElem.parentNode) {
                 this.floatingElem.parentNode.removeChild(this.floatingElem)
             }
             this.floatingRef = null
             this.floatingElem = null
-            delete (window as any).serverStatsFloating
         }
+    }
 
-        if (this.bottomBarRef) {
-            this.bottomBarRef.destroy()
-            if (this.bottomBarElem && this.bottomBarElem.parentNode) {
-                this.bottomBarElem.parentNode.removeChild(this.bottomBarElem)
-            }
-            this.bottomBarRef = null
-            this.bottomBarElem = null
-            delete (window as any).serverStatsBottomBar
+    private teardownAllTabs() {
+        if (this.observer) {
+            this.observer.disconnect()
+            this.observer = null
         }
+        if (this.scanTimer) {
+            clearInterval(this.scanTimer)
+            this.scanTimer = null
+        }
+        this.disposables.forEach(fn => fn())
+        this.disposables = []
+        this.attachedTabs.forEach(el => {
+            const instance = this.tabInstances.get(el)
+            if (instance) {
+                instance.teardown()
+            }
+        })
+        this.attachedTabs.clear()
+        this.tabInstances = new WeakMap()
+        this.tabElementMap.clear()
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,6 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap'
 import TabbyCoreModule, { ToolbarButtonProvider, ConfigProvider, TranslateService, AppService, ConfigService } from 'tabby-core'
 import { SettingsTabProvider } from 'tabby-settings'
 import { NgChartsModule } from 'ng2-charts'
-import * as fs from 'fs'
-import * as os from 'os'
-import * as path from 'path'
 
 import { ServerStatsConfigProvider } from './config'
 import { TRANSLATIONS } from './translations'
@@ -16,22 +13,6 @@ import { StatsToolbarButtonProvider } from './toolbar-button.provider'
 import { ServerStatsFloatingPanelComponent } from './components/floating-panel.component'
 import { ServerStatsBottomBarComponent } from './components/bottom-bar.component'
 import { ServerStatsSettingsComponent, ServerStatsSettingsTabProvider } from './components/settings.component'
-
-type TabInstance = {
-    teardown: () => void
-    timerId: any
-    collector: () => Promise<any>
-    state: any
-}
-
-const LOG_PATH = path.join(os.tmpdir(), 'tabby-server-stats.log')
-const logDebug = (message: string) => {
-    try {
-        fs.appendFileSync(LOG_PATH, `${new Date().toISOString()} ${message}\n`)
-    } catch {}
-}
-
-logDebug('[init] module loaded')
 
 @NgModule({
     imports: [CommonModule, FormsModule, NgChartsModule, TabbyCoreModule, NgbModule], 
@@ -46,537 +27,93 @@ logDebug('[init] module loaded')
 })
 export default class ServerStatsModule {
     private floatingRef: any = null
+    private bottomBarRef: any = null
     private floatingElem: HTMLElement | null = null
-    private activeDisplayMode: string | null = null
-    private tabInstances: WeakMap<HTMLElement, TabInstance> = new WeakMap()
-    private attachedTabs = new Set<HTMLElement>()
-    private tabElementMap = new Map<HTMLElement, any>()
-    private observer: MutationObserver | null = null
-    private disposables: Array<() => void> = []
-    private styleNode: HTMLStyleElement | null = null
-    private observerRetry: any = null
-    private failed = false
-    private mutationScheduled = false
-    private pendingAdded = new Set<HTMLElement>()
-    private pendingRemoved = new Set<HTMLElement>()
-    private mutationBurst = 0
-    private mutationBurstTimer: any = null
-    private scanTimer: any = null
+    private bottomBarElem: HTMLElement | null = null
 
     constructor(
-        private app: AppService, 
-        private config: ConfigService,
-        private componentFactoryResolver: ComponentFactoryResolver,
-        private appRef: ApplicationRef,
-        private injector: Injector,
-        private statsService: StatsService,
+        app: AppService, 
+        config: ConfigService,
+        componentFactoryResolver: ComponentFactoryResolver,
+        appRef: ApplicationRef,
+        injector: Injector,
         translate: TranslateService
     ) {
-        logDebug('[init] constructor start')
-        this.config.ready$.subscribe(() => {
+        config.ready$.subscribe(() => {
             setTimeout(() => {
-                this.safeRun('translations', () => {
-                    for (const [lang, trans] of Object.entries(TRANSLATIONS)) {
-                        translate.setTranslation(lang, trans, true);
-                    }
-                })
+                for (const [lang, trans] of Object.entries(TRANSLATIONS)) {
+                    translate.setTranslation(lang, trans, true);
+                }
             }, 1000);
         });
 
-        this.config.ready$.subscribe(() => {
+        const createComponent = (displayMode: string) => {
+            this.destroyComponents()
+
+            if (displayMode === 'floatingPanel') {
+                const floatingFactory = componentFactoryResolver.resolveComponentFactory(ServerStatsFloatingPanelComponent)
+                this.floatingRef = floatingFactory.create(injector)
+                appRef.attachView(this.floatingRef.hostView)
+                this.floatingElem = (this.floatingRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
+                document.body.appendChild(this.floatingElem);
+                (window as any).serverStatsFloating = this.floatingRef.instance;
+                this.floatingRef.changeDetectorRef.detectChanges();
+                setTimeout(() => this.floatingRef.instance.checkAndFetch(), 100);
+            } else {
+                const bottomBarFactory = componentFactoryResolver.resolveComponentFactory(ServerStatsBottomBarComponent)
+                this.bottomBarRef = bottomBarFactory.create(injector)
+                appRef.attachView(this.bottomBarRef.hostView)
+                this.bottomBarElem = (this.bottomBarRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
+                const targetContainer = document.querySelector('app-root > div > .content');
+                if (targetContainer) {
+                    targetContainer.appendChild(this.bottomBarElem);
+                } else {
+                    document.body.appendChild(this.bottomBarElem);
+                }
+                (window as any).serverStatsBottomBar = this.bottomBarRef.instance;
+                this.bottomBarRef.changeDetectorRef.detectChanges();
+                setTimeout(() => this.bottomBarRef.instance.checkAndFetch(), 100);
+            }
+        }
+
+        const getDisplayMode = () => {
+            return config.store.plugin?.serverStats?.displayMode || 'bottomBar'
+        }
+
+        config.ready$.subscribe(() => {
             setTimeout(() => {
-                logDebug('[event] config.ready')
-                this.safeRun('applyDisplayMode:ready', () => this.applyDisplayMode(this.getDisplayMode()))
+                createComponent(getDisplayMode())
             }, 500);
         })
 
-        this.config.changed$.subscribe(() => {
-            logDebug('[event] config.changed')
-            this.safeRun('applyDisplayMode:changed', () => this.applyDisplayMode(this.getDisplayMode()))
-        })
-        logDebug('[init] constructor end')
-    }
-
-    private getDisplayMode() {
-        return this.config.store.plugin?.serverStats?.displayMode || 'bottomBar'
-    }
-
-    private safeRun(label: string, fn: () => void) {
-        if (this.failed) {
-            return
-        }
-        try {
-            fn()
-        } catch (err) {
-            this.failed = true
-            logDebug(`[error] ${label}: ${err instanceof Error ? err.stack || err.message : String(err)}`)
-        }
-    }
-
-    private applyDisplayMode(mode: string) {
-        logDebug(`[state] applyDisplayMode ${mode}`)
-        const previousMode = this.activeDisplayMode
-        this.activeDisplayMode = mode
-
-        if (previousMode === mode) {
-            if (mode === 'bottomBar' && this.attachedTabs.size === 0) {
-                this.initializePerTabBars()
-            }
-            return
-        }
-
-        this.destroyFloating()
-        this.teardownAllTabs()
-
-        if (mode === 'floatingPanel') {
-            this.safeRun('createFloatingPanel', () => this.createFloatingPanel())
-        } else {
-            this.safeRun('ensureGlobalStyle', () => this.ensureGlobalStyle())
-            this.safeRun('initializePerTabBars', () => this.initializePerTabBars())
-        }
-    }
-
-    private createFloatingPanel() {
-        logDebug('[state] createFloatingPanel')
-        const floatingFactory = this.componentFactoryResolver.resolveComponentFactory(ServerStatsFloatingPanelComponent)
-        this.floatingRef = floatingFactory.create(this.injector)
-        this.appRef.attachView(this.floatingRef.hostView)
-        this.floatingElem = (this.floatingRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
-        document.body.appendChild(this.floatingElem);
-        this.floatingRef.changeDetectorRef.detectChanges();
-        setTimeout(() => this.floatingRef.instance.checkAndFetch(), 100);
-    }
-
-    private initializePerTabBars() {
-        logDebug('[state] initializePerTabBars')
-        this.safeRun('rebuildTabElementMap', () => this.rebuildTabElementMap())
-        this.safeRun('attachExistingTabs', () => this.attachExistingTabs())
-        this.safeRun('observeTabLifecycle', () => this.observeTabLifecycle())
-        this.safeRun('startMutationObserver', () => this.startMutationObserver())
-        this.safeRun('startScanTimer', () => this.startScanTimer())
-    }
-
-    private ensureGlobalStyle() {
-        if (this.styleNode) {
-            return
-        }
-        if (!document.head) {
-            this.scheduleObserverRetry()
-            return
-        }
-        logDebug('[state] ensureGlobalStyle')
-        const style = document.createElement('style')
-        style.setAttribute('data-server-stats-style', '1')
-        style.textContent = `
-            ssh-tab.server-stats-tab {
-                display: flex;
-                flex-direction: column;
-            }
-            ssh-tab.server-stats-tab > .server-stats-bottom-host {
-                flex: 0 0 auto;
-                width: 100%;
-            }
-            ssh-tab.server-stats-tab > *:not(.server-stats-bottom-host) {
-                flex: 1 1 auto;
-                min-height: 0;
-            }
-            .server-stats-bottom-host {
-                width: 100%;
-            }
-        `
-        document.head.appendChild(style)
-        this.styleNode = style
-    }
-
-    private attachExistingTabs() {
-        const content = document.querySelector('app-root > div > .content')
-        if (!content) {
-            logDebug('[state] attachExistingTabs: no content')
-            this.scheduleObserverRetry()
-            return
-        }
-        this.rebuildTabElementMap()
-        const candidates = content.querySelectorAll('ssh-tab')
-        logDebug(`[state] attachExistingTabs ${candidates.length}`)
-        candidates.forEach(el => this.attachToSshTab(el as HTMLElement))
-    }
-
-    private startMutationObserver() {
-        const target = this.getObserverTarget()
-        if (!target) {
-            logDebug('[state] startMutationObserver: no target')
-            this.scheduleObserverRetry()
-            return
-        }
-        logDebug('[state] startMutationObserver: ok')
-        if (this.observer) {
-            this.observer.disconnect()
-        }
-        this.observer = new MutationObserver(mutations => {
-            this.trackMutationBurst(mutations.length)
-            mutations.forEach(mutation => {
-                mutation.addedNodes.forEach(node => this.queueMutationNode(node, true))
-                mutation.removedNodes.forEach(node => this.queueMutationNode(node, false))
-            })
-            this.flushMutationQueue()
-        })
-        this.observer.observe(target, { childList: true, subtree: true })
-    }
-
-    private queueMutationNode(node: Node, added: boolean) {
-        if (!(node instanceof HTMLElement)) {
-            return
-        }
-        if (added) {
-            this.pendingAdded.add(node)
-        } else {
-            this.pendingRemoved.add(node)
-        }
-    }
-
-    private flushMutationQueue() {
-        if (this.mutationScheduled) {
-            return
-        }
-        this.mutationScheduled = true
-        window.setTimeout(() => {
-            this.mutationScheduled = false
-            this.pendingAdded.forEach(node => this.scanNodeForTabs(node))
-            this.pendingRemoved.forEach(node => this.handleRemovedNode(node))
-            this.pendingAdded.clear()
-            this.pendingRemoved.clear()
-        }, 0)
-    }
-
-    private getObserverTarget(): HTMLElement | null {
-        return (document.querySelector('app-root > div > .content') as HTMLElement) || null
-    }
-
-    private trackMutationBurst(count: number) {
-        this.mutationBurst += count
-        if (!this.mutationBurstTimer) {
-            this.mutationBurstTimer = window.setTimeout(() => {
-                this.mutationBurst = 0
-                this.mutationBurstTimer = null
-            }, 1000)
-        }
-        if (this.mutationBurst > 2000 && this.observer) {
-            logDebug('[state] mutation burst detected, disabling observer')
-            this.observer.disconnect()
-            this.observer = null
-        }
-    }
-
-    private scheduleObserverRetry() {
-        if (this.observerRetry) {
-            return
-        }
-        logDebug('[state] scheduleObserverRetry')
-        this.observerRetry = window.setTimeout(() => {
-            this.observerRetry = null
-            if (this.activeDisplayMode === 'bottomBar') {
-                logDebug('[state] observerRetry tick')
-                this.safeRun('ensureGlobalStyle:retry', () => this.ensureGlobalStyle())
-                this.safeRun('attachExistingTabs:retry', () => this.attachExistingTabs())
-                this.safeRun('startMutationObserver:retry', () => this.startMutationObserver())
-            }
-        }, 250)
-    }
-
-    private scanNodeForTabs(node: Node) {
-        if (!(node instanceof HTMLElement)) {
-            return
-        }
-        if (node.tagName && node.tagName.toLowerCase() === 'ssh-tab') {
-            this.attachToSshTab(node)
-            return
-        }
-        const inner = node.querySelectorAll('ssh-tab')
-        inner.forEach(el => this.attachToSshTab(el as HTMLElement))
-    }
-
-    private handleRemovedNode(node: Node) {
-        if (!(node instanceof HTMLElement)) {
-            return
-        }
-        if (node.tagName && node.tagName.toLowerCase() === 'ssh-tab') {
-            if (this.tabInstances.has(node)) {
-                this.detachFromTab(node)
-            }
-            return
-        }
-        const inner = node.querySelectorAll('ssh-tab')
-        inner.forEach(el => this.detachFromTab(el as HTMLElement))
-    }
-
-    private startScanTimer() {
-        if (this.scanTimer) {
-            return
-        }
-        this.scanTimer = window.setInterval(() => {
-            if (this.activeDisplayMode !== 'bottomBar') {
-                return
-            }
-            this.attachExistingTabs()
-        }, 1500)
-    }
-
-    private attachToSshTab(sshTabEl: HTMLElement) {
-        if (this.activeDisplayMode !== 'bottomBar') {
-            return
-        }
-        if (!sshTabEl || this.tabInstances.has(sshTabEl) || sshTabEl.getAttribute('data-ss-attached') === '1') {
-            return
-        }
-        logDebug('[state] attachToSshTab')
-
-        this.rebuildTabElementMap()
-        sshTabEl.setAttribute('data-ss-attached', '1')
-        sshTabEl.classList.add('server-stats-tab')
-
-        const host = document.createElement('div')
-        host.classList.add('server-stats-bottom-host')
-        host.setAttribute('data-ss-host', '1')
-        sshTabEl.appendChild(host)
-
-        const barFactory = this.componentFactoryResolver.resolveComponentFactory(ServerStatsBottomBarComponent)
-        const barRef = barFactory.create(this.injector)
-        const session = this.resolveSessionForElement(sshTabEl)
-        if ((barRef.instance as any).useExternalController !== undefined) {
-            (barRef.instance as any).useExternalController = true
-        }
-        if ((barRef.instance as any).bindToSession) {
-            (barRef.instance as any).bindToSession(session)
-        }
-        this.appRef.attachView(barRef.hostView)
-        const barElem = (barRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
-        host.appendChild(barElem)
-        barRef.changeDetectorRef.detectChanges()
-
-        const state: any = { last: null }
-        let activeSession: any = session
-        const collector = async () => {
-            const resolvedSession = this.resolveSessionForElement(sshTabEl)
-            if (resolvedSession && resolvedSession !== activeSession) {
-                activeSession = resolvedSession
-                if ((barRef.instance as any).bindToSession) {
-                    (barRef.instance as any).bindToSession(activeSession)
-                }
-            }
-            if (!activeSession) {
-                return { data: null, session: null, supported: false }
-            }
-            const supported = this.statsService.isPlatformSupport(activeSession)
-            if (!supported) {
-                return { data: null, session: activeSession, supported: false }
-            }
-            const data = await this.statsService.fetchStats(activeSession)
-            return { data, session: activeSession, supported: true }
-        }
-
-        const runPoll = async () => {
-            const isEnabled = this.config.store.plugin?.serverStats?.enabled
-            const displayMode = this.getDisplayMode()
-            const result = await collector()
-            if (!result) {
-                return
-            }
-            if (!isEnabled || displayMode !== 'bottomBar' || !result.session) {
-                if ((barRef.instance as any).hideExternal) {
-                    (barRef.instance as any).hideExternal()
-                }
-                return
-            }
-            if (!result.supported) {
-                if ((barRef.instance as any).hideExternal) {
-                    (barRef.instance as any).hideExternal()
-                }
-                return
-            }
-            if (result.data) {
-                state.last = result.data
-                if ((barRef.instance as any).renderExternalStats) {
-                    (barRef.instance as any).renderExternalStats(result.data)
-                }
-            } else if ((barRef.instance as any).setExternalLoading) {
-                (barRef.instance as any).setExternalLoading(false)
-            }
-        }
-
-        if ((barRef.instance as any).setExternalLoading) {
-            (barRef.instance as any).setExternalLoading(true)
-        }
-        runPoll()
-        const timerId = window.setInterval(runPoll, 3000)
-
-        const teardown = () => {
-            if (timerId) {
-                clearInterval(timerId)
-            }
-            try {
-                barRef.destroy()
-            } catch {}
-            try {
-                this.appRef.detachView(barRef.hostView)
-            } catch {}
-            if (host.parentNode === sshTabEl) {
-                host.parentNode.removeChild(host)
-            }
-            sshTabEl.removeAttribute('data-ss-attached')
-            sshTabEl.classList.remove('server-stats-tab')
-        }
-
-        this.tabInstances.set(sshTabEl, { teardown, timerId, collector, state })
-        this.attachedTabs.add(sshTabEl)
-    }
-
-    private detachFromTab(tabEl: HTMLElement) {
-        const existing = this.tabInstances.get(tabEl)
-        if (existing) {
-            logDebug('[state] detachFromTab')
-            existing.teardown()
-            this.tabInstances.delete(tabEl)
-        }
-        this.attachedTabs.delete(tabEl)
-        this.tabElementMap.delete(tabEl)
-    }
-
-    private rebuildTabElementMap() {
-        this.tabElementMap.clear()
-        const tabs = this.getAllLeafTabs()
-        tabs.forEach(tab => {
-            const el = this.getTabElement(tab)
-            if (el) {
-                this.tabElementMap.set(el, tab)
+        config.changed$.subscribe(() => {
+            const currentMode = getDisplayMode()
+            const existingMode = this.floatingRef ? 'floatingPanel' : (this.bottomBarRef ? 'bottomBar' : null)
+            if (existingMode !== currentMode) {
+                createComponent(currentMode)
             }
         })
     }
 
-    private getAllLeafTabs(): any[] {
-        const result: any[] = []
-        const walk = (tab: any) => {
-            if (!tab) return
-            if (typeof tab.getAllTabs === 'function') {
-                const inner = tab.getAllTabs()
-                if (Array.isArray(inner)) {
-                    inner.forEach((t: any) => walk(t))
-                    return
-                }
-            }
-            result.push(tab)
-        }
-        if (Array.isArray(this.app.tabs)) {
-            this.app.tabs.forEach(tab => walk(tab))
-        }
-        return result
-    }
-
-    private getTabElement(tab: any): HTMLElement | null {
-        if (!tab) return null
-        const direct = tab.element && tab.element.nativeElement
-        if (direct instanceof HTMLElement) {
-            return direct
-        }
-        const hostView = tab.hostView && (tab.hostView as any).rootNodes
-        if (hostView && hostView[0] instanceof HTMLElement) {
-            return hostView[0]
-        }
-        const embedded = tab.viewContainerEmbeddedRef && tab.viewContainerEmbeddedRef.rootNodes
-        if (embedded && embedded[0] instanceof HTMLElement) {
-            return embedded[0]
-        }
-        return null
-    }
-
-    private resolveSessionForElement(el: HTMLElement): any {
-        const tab = this.tabElementMap.get(el)
-        if (tab) {
-            return this.resolveSessionFromTab(tab)
-        }
-        for (const [knownEl, knownTab] of this.tabElementMap.entries()) {
-            if (knownEl && knownEl.contains && knownEl.contains(el)) {
-                return this.resolveSessionFromTab(knownTab)
-            }
-        }
-        return null
-    }
-
-    private resolveSessionFromTab(tab: any): any {
-        if (!tab) return null
-        if (tab.session) return tab.session
-        if (tab.focusedTab) {
-            return this.resolveSessionFromTab(tab.focusedTab)
-        }
-        return null
-    }
-
-    private observeTabLifecycle() {
-        this.disposables.forEach(fn => fn())
-        this.disposables = []
-
-        const tabRemoved = this.app.tabRemoved$?.subscribe(tab => {
-            const el = this.getTabElement(tab)
-            if (el) {
-                this.detachFromTab(el)
-            }
-            this.rebuildTabElementMap()
-        })
-        const tabClosed = this.app.tabClosed$?.subscribe(tab => {
-            const el = this.getTabElement(tab)
-            if (el) {
-                this.detachFromTab(el)
-            }
-            this.rebuildTabElementMap()
-        })
-        const tabOpened = this.app.tabOpened$?.subscribe(() => {
-            this.rebuildTabElementMap()
-            this.attachExistingTabs()
-        })
-        const tabsChanged = this.app.tabsChanged$?.subscribe(() => {
-            this.rebuildTabElementMap()
-            this.attachExistingTabs()
-        })
-
-        ;[tabRemoved, tabClosed, tabOpened, tabsChanged].forEach(sub => {
-            if (sub && typeof sub.unsubscribe === 'function') {
-                this.disposables.push(() => sub.unsubscribe())
-            }
-        })
-    }
-
-    private destroyFloating() {
+    private destroyComponents() {
         if (this.floatingRef) {
-            try {
-                this.appRef.detachView(this.floatingRef.hostView)
-            } catch {}
             this.floatingRef.destroy()
             if (this.floatingElem && this.floatingElem.parentNode) {
                 this.floatingElem.parentNode.removeChild(this.floatingElem)
             }
             this.floatingRef = null
             this.floatingElem = null
+            delete (window as any).serverStatsFloating
         }
-    }
 
-    private teardownAllTabs() {
-        if (this.observer) {
-            this.observer.disconnect()
-            this.observer = null
-        }
-        if (this.scanTimer) {
-            clearInterval(this.scanTimer)
-            this.scanTimer = null
-        }
-        this.disposables.forEach(fn => fn())
-        this.disposables = []
-        this.attachedTabs.forEach(el => {
-            const instance = this.tabInstances.get(el)
-            if (instance) {
-                instance.teardown()
+        if (this.bottomBarRef) {
+            this.bottomBarRef.destroy()
+            if (this.bottomBarElem && this.bottomBarElem.parentNode) {
+                this.bottomBarElem.parentNode.removeChild(this.bottomBarElem)
             }
-        })
-        this.attachedTabs.clear()
-        this.tabInstances = new WeakMap()
-        this.tabElementMap.clear()
+            this.bottomBarRef = null
+            this.bottomBarElem = null
+            delete (window as any).serverStatsBottomBar
+        }
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ type TabInstance = {
     timerId: any
     collector: () => Promise<any>
     state: any
-    configSub: any
 }
 
 const LOG_PATH = path.join(os.tmpdir(), 'tabby-server-stats.log')
@@ -378,17 +377,11 @@ export default class ServerStatsModule {
         const runPoll = async () => {
             const isEnabled = this.config.store.plugin?.serverStats?.enabled
             const displayMode = this.getDisplayMode()
-            if (!isEnabled || displayMode !== 'bottomBar') {
-                if ((barRef.instance as any).hideExternal) {
-                    (barRef.instance as any).hideExternal()
-                }
-                return
-            }
             const result = await collector()
             if (!result) {
                 return
             }
-            if (!result.session) {
+            if (!isEnabled || displayMode !== 'bottomBar' || !result.session) {
                 if ((barRef.instance as any).hideExternal) {
                     (barRef.instance as any).hideExternal()
                 }
@@ -410,33 +403,15 @@ export default class ServerStatsModule {
             }
         }
 
-        const syncOnConfigChange = () => {
-            const isEnabled = this.config.store.plugin?.serverStats?.enabled
-            const displayMode = this.getDisplayMode()
-            if (!isEnabled || displayMode !== 'bottomBar') {
-                if ((barRef.instance as any).hideExternal) {
-                    (barRef.instance as any).hideExternal()
-                }
-                return
-            }
-            if ((barRef.instance as any).setExternalLoading) {
-                (barRef.instance as any).setExternalLoading(true)
-            }
-            runPoll()
+        if ((barRef.instance as any).setExternalLoading) {
+            (barRef.instance as any).setExternalLoading(true)
         }
-
-        syncOnConfigChange()
+        runPoll()
         const timerId = window.setInterval(runPoll, 3000)
-        const configSub = this.config.changed$?.subscribe(() => {
-            syncOnConfigChange()
-        })
 
         const teardown = () => {
             if (timerId) {
                 clearInterval(timerId)
-            }
-            if (configSub && typeof configSub.unsubscribe === 'function') {
-                configSub.unsubscribe()
             }
             try {
                 barRef.destroy()
@@ -451,7 +426,7 @@ export default class ServerStatsModule {
             sshTabEl.classList.remove('server-stats-tab')
         }
 
-        this.tabInstances.set(sshTabEl, { teardown, timerId, collector, state, configSub })
+        this.tabInstances.set(sshTabEl, { teardown, timerId, collector, state })
         this.attachedTabs.add(sshTabEl)
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap'
 import TabbyCoreModule, { ToolbarButtonProvider, ConfigProvider, TranslateService, AppService, ConfigService } from 'tabby-core'
 import { SettingsTabProvider } from 'tabby-settings'
 import { NgChartsModule } from 'ng2-charts'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
 
 import { ServerStatsConfigProvider } from './config'
 import { TRANSLATIONS } from './translations'
@@ -13,6 +16,22 @@ import { StatsToolbarButtonProvider } from './toolbar-button.provider'
 import { ServerStatsFloatingPanelComponent } from './components/floating-panel.component'
 import { ServerStatsBottomBarComponent } from './components/bottom-bar.component'
 import { ServerStatsSettingsComponent, ServerStatsSettingsTabProvider } from './components/settings.component'
+
+type TabInstance = {
+    teardown: () => void
+    timerId: any
+    collector: () => Promise<any>
+    state: any
+}
+
+const LOG_PATH = path.join(os.tmpdir(), 'tabby-server-stats.log')
+const logDebug = (message: string) => {
+    try {
+        fs.appendFileSync(LOG_PATH, `${new Date().toISOString()} ${message}\n`)
+    } catch {}
+}
+
+logDebug('[init] module loaded')
 
 @NgModule({
     imports: [CommonModule, FormsModule, NgChartsModule, TabbyCoreModule, NgbModule], 
@@ -27,93 +46,537 @@ import { ServerStatsSettingsComponent, ServerStatsSettingsTabProvider } from './
 })
 export default class ServerStatsModule {
     private floatingRef: any = null
-    private bottomBarRef: any = null
     private floatingElem: HTMLElement | null = null
-    private bottomBarElem: HTMLElement | null = null
+    private activeDisplayMode: string | null = null
+    private tabInstances: WeakMap<HTMLElement, TabInstance> = new WeakMap()
+    private attachedTabs = new Set<HTMLElement>()
+    private tabElementMap = new Map<HTMLElement, any>()
+    private observer: MutationObserver | null = null
+    private disposables: Array<() => void> = []
+    private styleNode: HTMLStyleElement | null = null
+    private observerRetry: any = null
+    private failed = false
+    private mutationScheduled = false
+    private pendingAdded = new Set<HTMLElement>()
+    private pendingRemoved = new Set<HTMLElement>()
+    private mutationBurst = 0
+    private mutationBurstTimer: any = null
+    private scanTimer: any = null
 
     constructor(
-        app: AppService, 
-        config: ConfigService,
-        componentFactoryResolver: ComponentFactoryResolver,
-        appRef: ApplicationRef,
-        injector: Injector,
+        private app: AppService, 
+        private config: ConfigService,
+        private componentFactoryResolver: ComponentFactoryResolver,
+        private appRef: ApplicationRef,
+        private injector: Injector,
+        private statsService: StatsService,
         translate: TranslateService
     ) {
-        config.ready$.subscribe(() => {
+        logDebug('[init] constructor start')
+        this.config.ready$.subscribe(() => {
             setTimeout(() => {
-                for (const [lang, trans] of Object.entries(TRANSLATIONS)) {
-                    translate.setTranslation(lang, trans, true);
-                }
+                this.safeRun('translations', () => {
+                    for (const [lang, trans] of Object.entries(TRANSLATIONS)) {
+                        translate.setTranslation(lang, trans, true);
+                    }
+                })
             }, 1000);
         });
 
-        const createComponent = (displayMode: string) => {
-            this.destroyComponents()
-
-            if (displayMode === 'floatingPanel') {
-                const floatingFactory = componentFactoryResolver.resolveComponentFactory(ServerStatsFloatingPanelComponent)
-                this.floatingRef = floatingFactory.create(injector)
-                appRef.attachView(this.floatingRef.hostView)
-                this.floatingElem = (this.floatingRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
-                document.body.appendChild(this.floatingElem);
-                (window as any).serverStatsFloating = this.floatingRef.instance;
-                this.floatingRef.changeDetectorRef.detectChanges();
-                setTimeout(() => this.floatingRef.instance.checkAndFetch(), 100);
-            } else {
-                const bottomBarFactory = componentFactoryResolver.resolveComponentFactory(ServerStatsBottomBarComponent)
-                this.bottomBarRef = bottomBarFactory.create(injector)
-                appRef.attachView(this.bottomBarRef.hostView)
-                this.bottomBarElem = (this.bottomBarRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
-                const targetContainer = document.querySelector('app-root > div > .content');
-                if (targetContainer) {
-                    targetContainer.appendChild(this.bottomBarElem);
-                } else {
-                    document.body.appendChild(this.bottomBarElem);
-                }
-                (window as any).serverStatsBottomBar = this.bottomBarRef.instance;
-                this.bottomBarRef.changeDetectorRef.detectChanges();
-                setTimeout(() => this.bottomBarRef.instance.checkAndFetch(), 100);
-            }
-        }
-
-        const getDisplayMode = () => {
-            return config.store.plugin?.serverStats?.displayMode || 'bottomBar'
-        }
-
-        config.ready$.subscribe(() => {
+        this.config.ready$.subscribe(() => {
             setTimeout(() => {
-                createComponent(getDisplayMode())
+                logDebug('[event] config.ready')
+                this.safeRun('applyDisplayMode:ready', () => this.applyDisplayMode(this.getDisplayMode()))
             }, 500);
         })
 
-        config.changed$.subscribe(() => {
-            const currentMode = getDisplayMode()
-            const existingMode = this.floatingRef ? 'floatingPanel' : (this.bottomBarRef ? 'bottomBar' : null)
-            if (existingMode !== currentMode) {
-                createComponent(currentMode)
+        this.config.changed$.subscribe(() => {
+            logDebug('[event] config.changed')
+            this.safeRun('applyDisplayMode:changed', () => this.applyDisplayMode(this.getDisplayMode()))
+        })
+        logDebug('[init] constructor end')
+    }
+
+    private getDisplayMode() {
+        return this.config.store.plugin?.serverStats?.displayMode || 'bottomBar'
+    }
+
+    private safeRun(label: string, fn: () => void) {
+        if (this.failed) {
+            return
+        }
+        try {
+            fn()
+        } catch (err) {
+            this.failed = true
+            logDebug(`[error] ${label}: ${err instanceof Error ? err.stack || err.message : String(err)}`)
+        }
+    }
+
+    private applyDisplayMode(mode: string) {
+        logDebug(`[state] applyDisplayMode ${mode}`)
+        const previousMode = this.activeDisplayMode
+        this.activeDisplayMode = mode
+
+        if (previousMode === mode) {
+            if (mode === 'bottomBar' && this.attachedTabs.size === 0) {
+                this.initializePerTabBars()
+            }
+            return
+        }
+
+        this.destroyFloating()
+        this.teardownAllTabs()
+
+        if (mode === 'floatingPanel') {
+            this.safeRun('createFloatingPanel', () => this.createFloatingPanel())
+        } else {
+            this.safeRun('ensureGlobalStyle', () => this.ensureGlobalStyle())
+            this.safeRun('initializePerTabBars', () => this.initializePerTabBars())
+        }
+    }
+
+    private createFloatingPanel() {
+        logDebug('[state] createFloatingPanel')
+        const floatingFactory = this.componentFactoryResolver.resolveComponentFactory(ServerStatsFloatingPanelComponent)
+        this.floatingRef = floatingFactory.create(this.injector)
+        this.appRef.attachView(this.floatingRef.hostView)
+        this.floatingElem = (this.floatingRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
+        document.body.appendChild(this.floatingElem);
+        this.floatingRef.changeDetectorRef.detectChanges();
+        setTimeout(() => this.floatingRef.instance.checkAndFetch(), 100);
+    }
+
+    private initializePerTabBars() {
+        logDebug('[state] initializePerTabBars')
+        this.safeRun('rebuildTabElementMap', () => this.rebuildTabElementMap())
+        this.safeRun('attachExistingTabs', () => this.attachExistingTabs())
+        this.safeRun('observeTabLifecycle', () => this.observeTabLifecycle())
+        this.safeRun('startMutationObserver', () => this.startMutationObserver())
+        this.safeRun('startScanTimer', () => this.startScanTimer())
+    }
+
+    private ensureGlobalStyle() {
+        if (this.styleNode) {
+            return
+        }
+        if (!document.head) {
+            this.scheduleObserverRetry()
+            return
+        }
+        logDebug('[state] ensureGlobalStyle')
+        const style = document.createElement('style')
+        style.setAttribute('data-server-stats-style', '1')
+        style.textContent = `
+            ssh-tab.server-stats-tab {
+                display: flex;
+                flex-direction: column;
+            }
+            ssh-tab.server-stats-tab > .server-stats-bottom-host {
+                flex: 0 0 auto;
+                width: 100%;
+            }
+            ssh-tab.server-stats-tab > *:not(.server-stats-bottom-host) {
+                flex: 1 1 auto;
+                min-height: 0;
+            }
+            .server-stats-bottom-host {
+                width: 100%;
+            }
+        `
+        document.head.appendChild(style)
+        this.styleNode = style
+    }
+
+    private attachExistingTabs() {
+        const content = document.querySelector('app-root > div > .content')
+        if (!content) {
+            logDebug('[state] attachExistingTabs: no content')
+            this.scheduleObserverRetry()
+            return
+        }
+        this.rebuildTabElementMap()
+        const candidates = content.querySelectorAll('ssh-tab')
+        logDebug(`[state] attachExistingTabs ${candidates.length}`)
+        candidates.forEach(el => this.attachToSshTab(el as HTMLElement))
+    }
+
+    private startMutationObserver() {
+        const target = this.getObserverTarget()
+        if (!target) {
+            logDebug('[state] startMutationObserver: no target')
+            this.scheduleObserverRetry()
+            return
+        }
+        logDebug('[state] startMutationObserver: ok')
+        if (this.observer) {
+            this.observer.disconnect()
+        }
+        this.observer = new MutationObserver(mutations => {
+            this.trackMutationBurst(mutations.length)
+            mutations.forEach(mutation => {
+                mutation.addedNodes.forEach(node => this.queueMutationNode(node, true))
+                mutation.removedNodes.forEach(node => this.queueMutationNode(node, false))
+            })
+            this.flushMutationQueue()
+        })
+        this.observer.observe(target, { childList: true, subtree: true })
+    }
+
+    private queueMutationNode(node: Node, added: boolean) {
+        if (!(node instanceof HTMLElement)) {
+            return
+        }
+        if (added) {
+            this.pendingAdded.add(node)
+        } else {
+            this.pendingRemoved.add(node)
+        }
+    }
+
+    private flushMutationQueue() {
+        if (this.mutationScheduled) {
+            return
+        }
+        this.mutationScheduled = true
+        window.setTimeout(() => {
+            this.mutationScheduled = false
+            this.pendingAdded.forEach(node => this.scanNodeForTabs(node))
+            this.pendingRemoved.forEach(node => this.handleRemovedNode(node))
+            this.pendingAdded.clear()
+            this.pendingRemoved.clear()
+        }, 0)
+    }
+
+    private getObserverTarget(): HTMLElement | null {
+        return (document.querySelector('app-root > div > .content') as HTMLElement) || null
+    }
+
+    private trackMutationBurst(count: number) {
+        this.mutationBurst += count
+        if (!this.mutationBurstTimer) {
+            this.mutationBurstTimer = window.setTimeout(() => {
+                this.mutationBurst = 0
+                this.mutationBurstTimer = null
+            }, 1000)
+        }
+        if (this.mutationBurst > 2000 && this.observer) {
+            logDebug('[state] mutation burst detected, disabling observer')
+            this.observer.disconnect()
+            this.observer = null
+        }
+    }
+
+    private scheduleObserverRetry() {
+        if (this.observerRetry) {
+            return
+        }
+        logDebug('[state] scheduleObserverRetry')
+        this.observerRetry = window.setTimeout(() => {
+            this.observerRetry = null
+            if (this.activeDisplayMode === 'bottomBar') {
+                logDebug('[state] observerRetry tick')
+                this.safeRun('ensureGlobalStyle:retry', () => this.ensureGlobalStyle())
+                this.safeRun('attachExistingTabs:retry', () => this.attachExistingTabs())
+                this.safeRun('startMutationObserver:retry', () => this.startMutationObserver())
+            }
+        }, 250)
+    }
+
+    private scanNodeForTabs(node: Node) {
+        if (!(node instanceof HTMLElement)) {
+            return
+        }
+        if (node.tagName && node.tagName.toLowerCase() === 'ssh-tab') {
+            this.attachToSshTab(node)
+            return
+        }
+        const inner = node.querySelectorAll('ssh-tab')
+        inner.forEach(el => this.attachToSshTab(el as HTMLElement))
+    }
+
+    private handleRemovedNode(node: Node) {
+        if (!(node instanceof HTMLElement)) {
+            return
+        }
+        if (node.tagName && node.tagName.toLowerCase() === 'ssh-tab') {
+            if (this.tabInstances.has(node)) {
+                this.detachFromTab(node)
+            }
+            return
+        }
+        const inner = node.querySelectorAll('ssh-tab')
+        inner.forEach(el => this.detachFromTab(el as HTMLElement))
+    }
+
+    private startScanTimer() {
+        if (this.scanTimer) {
+            return
+        }
+        this.scanTimer = window.setInterval(() => {
+            if (this.activeDisplayMode !== 'bottomBar') {
+                return
+            }
+            this.attachExistingTabs()
+        }, 1500)
+    }
+
+    private attachToSshTab(sshTabEl: HTMLElement) {
+        if (this.activeDisplayMode !== 'bottomBar') {
+            return
+        }
+        if (!sshTabEl || this.tabInstances.has(sshTabEl) || sshTabEl.getAttribute('data-ss-attached') === '1') {
+            return
+        }
+        logDebug('[state] attachToSshTab')
+
+        this.rebuildTabElementMap()
+        sshTabEl.setAttribute('data-ss-attached', '1')
+        sshTabEl.classList.add('server-stats-tab')
+
+        const host = document.createElement('div')
+        host.classList.add('server-stats-bottom-host')
+        host.setAttribute('data-ss-host', '1')
+        sshTabEl.appendChild(host)
+
+        const barFactory = this.componentFactoryResolver.resolveComponentFactory(ServerStatsBottomBarComponent)
+        const barRef = barFactory.create(this.injector)
+        const session = this.resolveSessionForElement(sshTabEl)
+        if ((barRef.instance as any).useExternalController !== undefined) {
+            (barRef.instance as any).useExternalController = true
+        }
+        if ((barRef.instance as any).bindToSession) {
+            (barRef.instance as any).bindToSession(session)
+        }
+        this.appRef.attachView(barRef.hostView)
+        const barElem = (barRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement
+        host.appendChild(barElem)
+        barRef.changeDetectorRef.detectChanges()
+
+        const state: any = { last: null }
+        let activeSession: any = session
+        const collector = async () => {
+            const resolvedSession = this.resolveSessionForElement(sshTabEl)
+            if (resolvedSession && resolvedSession !== activeSession) {
+                activeSession = resolvedSession
+                if ((barRef.instance as any).bindToSession) {
+                    (barRef.instance as any).bindToSession(activeSession)
+                }
+            }
+            if (!activeSession) {
+                return { data: null, session: null, supported: false }
+            }
+            const supported = this.statsService.isPlatformSupport(activeSession)
+            if (!supported) {
+                return { data: null, session: activeSession, supported: false }
+            }
+            const data = await this.statsService.fetchStats(activeSession)
+            return { data, session: activeSession, supported: true }
+        }
+
+        const runPoll = async () => {
+            const isEnabled = this.config.store.plugin?.serverStats?.enabled
+            const displayMode = this.getDisplayMode()
+            const result = await collector()
+            if (!result) {
+                return
+            }
+            if (!isEnabled || displayMode !== 'bottomBar' || !result.session) {
+                if ((barRef.instance as any).hideExternal) {
+                    (barRef.instance as any).hideExternal()
+                }
+                return
+            }
+            if (!result.supported) {
+                if ((barRef.instance as any).hideExternal) {
+                    (barRef.instance as any).hideExternal()
+                }
+                return
+            }
+            if (result.data) {
+                state.last = result.data
+                if ((barRef.instance as any).renderExternalStats) {
+                    (barRef.instance as any).renderExternalStats(result.data)
+                }
+            } else if ((barRef.instance as any).setExternalLoading) {
+                (barRef.instance as any).setExternalLoading(false)
+            }
+        }
+
+        if ((barRef.instance as any).setExternalLoading) {
+            (barRef.instance as any).setExternalLoading(true)
+        }
+        runPoll()
+        const timerId = window.setInterval(runPoll, 3000)
+
+        const teardown = () => {
+            if (timerId) {
+                clearInterval(timerId)
+            }
+            try {
+                barRef.destroy()
+            } catch {}
+            try {
+                this.appRef.detachView(barRef.hostView)
+            } catch {}
+            if (host.parentNode === sshTabEl) {
+                host.parentNode.removeChild(host)
+            }
+            sshTabEl.removeAttribute('data-ss-attached')
+            sshTabEl.classList.remove('server-stats-tab')
+        }
+
+        this.tabInstances.set(sshTabEl, { teardown, timerId, collector, state })
+        this.attachedTabs.add(sshTabEl)
+    }
+
+    private detachFromTab(tabEl: HTMLElement) {
+        const existing = this.tabInstances.get(tabEl)
+        if (existing) {
+            logDebug('[state] detachFromTab')
+            existing.teardown()
+            this.tabInstances.delete(tabEl)
+        }
+        this.attachedTabs.delete(tabEl)
+        this.tabElementMap.delete(tabEl)
+    }
+
+    private rebuildTabElementMap() {
+        this.tabElementMap.clear()
+        const tabs = this.getAllLeafTabs()
+        tabs.forEach(tab => {
+            const el = this.getTabElement(tab)
+            if (el) {
+                this.tabElementMap.set(el, tab)
             }
         })
     }
 
-    private destroyComponents() {
+    private getAllLeafTabs(): any[] {
+        const result: any[] = []
+        const walk = (tab: any) => {
+            if (!tab) return
+            if (typeof tab.getAllTabs === 'function') {
+                const inner = tab.getAllTabs()
+                if (Array.isArray(inner)) {
+                    inner.forEach((t: any) => walk(t))
+                    return
+                }
+            }
+            result.push(tab)
+        }
+        if (Array.isArray(this.app.tabs)) {
+            this.app.tabs.forEach(tab => walk(tab))
+        }
+        return result
+    }
+
+    private getTabElement(tab: any): HTMLElement | null {
+        if (!tab) return null
+        const direct = tab.element && tab.element.nativeElement
+        if (direct instanceof HTMLElement) {
+            return direct
+        }
+        const hostView = tab.hostView && (tab.hostView as any).rootNodes
+        if (hostView && hostView[0] instanceof HTMLElement) {
+            return hostView[0]
+        }
+        const embedded = tab.viewContainerEmbeddedRef && tab.viewContainerEmbeddedRef.rootNodes
+        if (embedded && embedded[0] instanceof HTMLElement) {
+            return embedded[0]
+        }
+        return null
+    }
+
+    private resolveSessionForElement(el: HTMLElement): any {
+        const tab = this.tabElementMap.get(el)
+        if (tab) {
+            return this.resolveSessionFromTab(tab)
+        }
+        for (const [knownEl, knownTab] of this.tabElementMap.entries()) {
+            if (knownEl && knownEl.contains && knownEl.contains(el)) {
+                return this.resolveSessionFromTab(knownTab)
+            }
+        }
+        return null
+    }
+
+    private resolveSessionFromTab(tab: any): any {
+        if (!tab) return null
+        if (tab.session) return tab.session
+        if (tab.focusedTab) {
+            return this.resolveSessionFromTab(tab.focusedTab)
+        }
+        return null
+    }
+
+    private observeTabLifecycle() {
+        this.disposables.forEach(fn => fn())
+        this.disposables = []
+
+        const tabRemoved = this.app.tabRemoved$?.subscribe(tab => {
+            const el = this.getTabElement(tab)
+            if (el) {
+                this.detachFromTab(el)
+            }
+            this.rebuildTabElementMap()
+        })
+        const tabClosed = this.app.tabClosed$?.subscribe(tab => {
+            const el = this.getTabElement(tab)
+            if (el) {
+                this.detachFromTab(el)
+            }
+            this.rebuildTabElementMap()
+        })
+        const tabOpened = this.app.tabOpened$?.subscribe(() => {
+            this.rebuildTabElementMap()
+            this.attachExistingTabs()
+        })
+        const tabsChanged = this.app.tabsChanged$?.subscribe(() => {
+            this.rebuildTabElementMap()
+            this.attachExistingTabs()
+        })
+
+        ;[tabRemoved, tabClosed, tabOpened, tabsChanged].forEach(sub => {
+            if (sub && typeof sub.unsubscribe === 'function') {
+                this.disposables.push(() => sub.unsubscribe())
+            }
+        })
+    }
+
+    private destroyFloating() {
         if (this.floatingRef) {
+            try {
+                this.appRef.detachView(this.floatingRef.hostView)
+            } catch {}
             this.floatingRef.destroy()
             if (this.floatingElem && this.floatingElem.parentNode) {
                 this.floatingElem.parentNode.removeChild(this.floatingElem)
             }
             this.floatingRef = null
             this.floatingElem = null
-            delete (window as any).serverStatsFloating
         }
+    }
 
-        if (this.bottomBarRef) {
-            this.bottomBarRef.destroy()
-            if (this.bottomBarElem && this.bottomBarElem.parentNode) {
-                this.bottomBarElem.parentNode.removeChild(this.bottomBarElem)
-            }
-            this.bottomBarRef = null
-            this.bottomBarElem = null
-            delete (window as any).serverStatsBottomBar
+    private teardownAllTabs() {
+        if (this.observer) {
+            this.observer.disconnect()
+            this.observer = null
         }
+        if (this.scanTimer) {
+            clearInterval(this.scanTimer)
+            this.scanTimer = null
+        }
+        this.disposables.forEach(fn => fn())
+        this.disposables = []
+        this.attachedTabs.forEach(el => {
+            const instance = this.tabInstances.get(el)
+            if (instance) {
+                instance.teardown()
+            }
+        })
+        this.attachedTabs.clear()
+        this.tabInstances = new WeakMap()
+        this.tabElementMap.clear()
     }
 }

--- a/src/services/stats.service.ts
+++ b/src/services/stats.service.ts
@@ -8,7 +8,7 @@ export class StatsService {
     // 修复：支持 Linux 和 macOS，增强了错误处理和环境兼容性
     // Thanks: https://blog.csdn.net/weixin_41635157/article/details/156060209?spm=1011.2415.3001.5331
     private baseStatsCommand = `export LC_ALL=C; PATH=$PATH:/usr/bin:/bin:/usr/sbin:/sbin; OS=$(uname -s 2>/dev/null || echo "Linux"); if [ "$OS" = "Darwin" ]; then cpu=$(ps -A -o %cpu | awk '{s+=$1} END {print s}' 2>/dev/null || echo "0"); mem=$(ps -A -o %mem | awk '{s+=$1} END {print s}' 2>/dev/null || echo "0"); disk=$(df -h / 2>/dev/null | awk 'NR==2{print $5}' | sed 's/%//' || echo "0"); echo "TABBY-STATS-START $cpu 0 0 $mem $disk"; else stats=$( (grep 'cpu ' /proc/stat; awk 'NR>2 {r+=$2; t+=$10} END{print r, t}' /proc/net/dev; sleep 1; grep 'cpu ' /proc/stat; awk 'NR>2 {r+=$2; t+=$10} END{print r, t}' /proc/net/dev) 2>/dev/null | awk 'NR==1 {t1=$2+$3+$4+$5+$6+$7+$8; i1=$5} NR==2 {rx1=$1; tx1=$2} NR==3 {t2=$2+$3+$4+$5+$6+$7+$8; i2=$5} NR==4 {rx2=$1; tx2=$2} END { dt=t2-t1; di=i2-i1; cpu=(dt<=0)?0:(dt-di)/dt*100; rx=rx2-rx1; tx=tx2-tx1; printf "%.1f %.0f %.0f", cpu, rx, tx }' ); mem=$(free 2>/dev/null | awk 'NR==2{printf "%.2f", $3*100/$2 }'); disk=$(df -h / 2>/dev/null | awk 'NR==2{print $5}' | sed 's/%//'); if [ -z "$stats" ]; then stats="0 0 0"; fi; if [ -z "$mem" ]; then mem="0"; fi; if [ -z "$disk" ]; then disk="0"; fi; echo "TABBY-STATS-START $stats $mem $disk"; fi`
-    private fetchGuards = new WeakMap<any, boolean>();
+    private isFetching = false;
 
     constructor(private config: ConfigService) {}
 
@@ -19,12 +19,8 @@ export class StatsService {
     }
 
     async fetchStats(session: any): Promise<any | null> {
-        if (!session) return null;
-
-        if (this.fetchGuards.get(session)) {
-            return null;
-        }
-        this.fetchGuards.set(session, true);
+        if (!session || this.isFetching) return null;
+        this.isFetching = true;
         
         try {
             const sshClient = session.ssh && session.ssh.ssh ? session.ssh.ssh : null;
@@ -32,7 +28,7 @@ export class StatsService {
             const isLocalSupported = !isSSH && (process.platform === 'linux' || process.platform === 'darwin');
 
             if (!isSSH && !isLocalSupported) {
-                this.fetchGuards.delete(session);
+                this.isFetching = false;
                 return null;
             }
 
@@ -59,7 +55,7 @@ export class StatsService {
             }
 
             if (!output) {
-                this.fetchGuards.delete(session);
+                this.isFetching = false;
                 return null;
             }
 
@@ -84,12 +80,12 @@ export class StatsService {
                 }));
             }
 
-            this.fetchGuards.delete(session);
+            this.isFetching = false;
             return result;
 
         } catch (e) {
             // console.error('Stats: Fetch Error:', e);
-            this.fetchGuards.delete(session);
+            this.isFetching = false;
         }
         
         return null;


### PR DESCRIPTION
## Background

The previous implementation relied on a single global instance, which could mix state/polling/communication across tabs. It also appended the bar directly under `.content`, which could conflict with the tab layout flow.

## Problem Summary

- Shared state across tabs → risk of mixing stats from different servers
- Shared timer/collector → no true per-tab isolation
- Incomplete cleanup when a tab closes → potential resource leaks
- Poor wrapping/auto-height on narrow widths
- Toggle response was tied to polling interval

## Solution Summary

- Create a fully independent instance set **per `ssh-tab`**
- Remove `.content` direct append; create/attach only inside `ssh-tab`
- Add initial scan + `MutationObserver` for dynamic tabs
- Split polling/requests per session (`WeakMap`)
- Enable wrap/auto-height for responsive layout
- Make toggle apply immediately

---

## Detailed Changes

### 1) Instance Management

**Before**

- Single global instance (`bottomBarRef`, `serverStatsBottomBar`)
- Shared timer/state

**After**

- `WeakMap<sshTabEl, { bar, collector, timerId, state, teardown }>` per tab
- Track active tabs via a `Set`
- Independent state/timer/collector per tab

### 2) DOM Attachment

**Before**

- Append bottom bar directly under `.content`

**After**

- Create/attach only inside `ssh-tab`
- Remove `.content` direct append flow
- Initial scan for existing tabs + `MutationObserver` for new tabs

### 3) Polling / Collection / Communication

**Before**

- Shared collector/timer
- Possible shared session/communication

**After**

- Per-tab collector and `timerId`
- `StatsService` uses session-keyed `WeakMap` to separate requests
- Each tab talks to its own server context

### 4) Lifecycle Cleanup

**Before**

- Cleanup on tab close was incomplete

**After**

- On `ssh-tab` removal: clear timer, remove bar, delete `WeakMap` entry
- On plugin unload: teardown all tabs and disconnect observers

### 5) UI / Layout

**Before**

- Overlay/absolute positioning could cause overlap
- Poor wrap/height behavior on small widths

**After**

- Layout flows inside `ssh-tab`
- `.stats-container` uses `flex-wrap`
- Auto height expansion and improved separator behavior

### 6) Toggle Responsiveness

**Before**

- Toggle often waited for next polling cycle

**After**

- Immediate render/hide on config change
- Optional immediate polling to refresh state

---

## Key Files

- `index.ts`
	- `ssh-tab` scan / `MutationObserver` / scan timer
	- per-tab `WeakMap` management
	- tab cleanup logic
- `bottom-bar.component.ts`
	- external control / session binding
	- wrap / auto-height styling
- `stats.service.ts`
	- session-keyed request separation (`WeakMap`)

---

## Test Checklist

- [ ] Open 2+ `ssh-tabs` → each shows its own bottom bar
- [ ] Each tab polls independently with isolated state
- [ ] Closing a tab only removes its own bar
- [ ] Narrow width → wraps lines and grows in height
- [ ] `[show server stats]` toggle responds immediately

---

## Risks / Notes

- Polling/communication increases linearly with number of tabs (performance optimization is a follow-up)