### PR TITLE
Add Linux sysadmin presets: SSH Sessions, I/O Wait, Failed Units

### DIFF
--- a/presets.json
+++ b/presets.json
@@ -41,5 +41,26 @@
     "color": "#76b900",
     "maxValue": 100,
     "suffix": "%"
+  },
+  {
+    "label": "SSH Sessions",
+    "command": "ss -tn src :22 | grep -c ESTAB",
+    "type": "text",
+    "color": "#00ff00",
+    "suffix": ""
+  },
+  {
+    "label": "I/O Wait",
+    "command": "iostat -c 1 1 | awk 'NR==4{print $4}'",
+    "type": "text",
+    "color": "#fdcb6e",
+    "suffix": "%"
+  },
+  {
+    "label": "Failed Units",
+    "command": "systemctl --failed --no-legend | wc -l",
+    "type": "text",
+    "color": "#ff7675",
+    "suffix": ""
   }
 ]


### PR DESCRIPTION
Adds three community presets useful for Linux server monitoring:

- **SSH Sessions** — active inbound SSH connections via `ss` (no extra dependencies)
- **I/O Wait** — CPU I/O wait % via `iostat` (requires `sysstat`)
- **Failed Units** — count of failed systemd units (systemd-based systems only)

These complement the existing presets well and cover common sysadmin monitoring needs that aren't yet in the preset list.