### PR TITLE
Fix runaway CPU: stop MutationObserver reacting to in-terminal DOM churn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -214,12 +214,28 @@ export default class ServerStatsModule {
             this.observer.disconnect()
         }
         this.observer = new MutationObserver(mutations => {
-            this.trackMutationBurst(mutations.length)
+            let relevant = 0
             mutations.forEach(mutation => {
+                // Ignore DOM churn that happens *inside* an existing terminal tab.
+                // xterm.js continuously rewrites its own DOM (rendered output and the
+                // blinking cursor); reacting to that turned this observer into a CPU
+                // hot path (100% main-thread JS). New ssh-tab elements are inserted at
+                // the tab-host level, whose target is not inside an ssh-tab, so they
+                // are still captured.
+                const target = mutation.target as HTMLElement
+                if (target && typeof target.closest === 'function' && target.closest('ssh-tab')) {
+                    return
+                }
                 mutation.addedNodes.forEach(node => this.queueMutationNode(node, true))
                 mutation.removedNodes.forEach(node => this.queueMutationNode(node, false))
+                relevant++
             })
-            this.flushMutationQueue()
+            // Only count tab-level mutations toward the burst breaker, so ordinary
+            // terminal output (filtered out above) never trips it.
+            if (relevant > 0) {
+                this.trackMutationBurst(relevant)
+                this.flushMutationQueue()
+            }
         })
         this.observer.observe(target, { childList: true, subtree: true })
     }


### PR DESCRIPTION
## Problem

The plugin observes `app-root` content with `{ childList: true, subtree: true }`. xterm.js rewrites its DOM continuously (rendered output + cursor blink), so the `MutationObserver` callback fired on **every** terminal DOM change and ran `querySelectorAll('ssh-tab')` per node — a 100% main-thread JS hot path.

Over uptime and on busy panes this ran away: a single renderer core pinned at 100%+ and the Electron renderer leaked to ~680 MB after ~7 days. (The existing `mutationBurst > 2000 → disconnect` guard suggests this was encountered before.)

## Fix

- Ignore any mutation whose `target` is inside an existing `ssh-tab` (i.e. terminal content). New `ssh-tab` elements are inserted at the tab-host level, whose target is *not* inside an `ssh-tab`, so they are still detected.
- Count only tab-level (relevant) mutations toward the burst breaker, so ordinary terminal output no longer trips it and needlessly disconnects the observer.

No behavior change to stats display or tab attach/detach.

## Verification

Reproduced a renderer pinned at 136% CPU. After this change, with the same layout and active SSH panes, renderer CPU dropped to single digits and the stats bar continued working normally.